### PR TITLE
Deploy front end to static web app instead of a blob

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -45,30 +45,9 @@ jobs:
                   npm run build
               working-directory: frontend
 
-            - name: Azure CLI Login
-              uses: azure/login@v2
-              with:
-                  client-id: ${{ secrets.AZURE_CLIENT_ID }}
-                  tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-                  subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-            - name: Delete old front end files
-              uses: azure/cli@v2
-              with:
-                  azcliversion: latest
-                  inlineScript: |
-                      az storage blob delete-batch \
-                      --account-name agkcal \
-                      --source '$web' \
-                      --auth-mode login
-
             - name: Deploy front end
-              uses: azure/cli@v2
+              uses: Azure/static-web-apps-deploy@v1
               with:
-                  azcliversion: latest
-                  inlineScript: |
-                      az storage blob upload-batch \
-                      --account-name agkcal \
-                      --destination '$web' \
-                      --source ./frontend/dist \
-                      --auth-mode login
+                  azure_static_web_apps_api_token: ${{ secrets.AZURE_FRONTEND_DEPLOYMENT_TOKEN }}
+                  app_location: "./frontend/dist"
+                  skip_app_build: true


### PR DESCRIPTION
Deploying an Azure static web app to a blob was functional, but did not have automatic HTTPS configuration for a custom domain. Adding HTTPS to a custom domain for container storage requires either Azure CDN or Front Door, each of which cost money without a free tier option. Static Web Apps allows for up to two custom domains within free tier, so I'm switching over to that.