### PR TITLE
CI/CD Optimization

### DIFF
--- a/.github/workflows/cd_back.yaml
+++ b/.github/workflows/cd_back.yaml
@@ -1,18 +1,21 @@
-name: cd
+name: cd_back
 
 on:
     push:
         branches:
             - main
+        paths:
+            - "backend/**"
+            - "docker-compose.yaml"
+            - ".github/workflows/cd_back.yaml"
+            - ".github/workflows/cd_front.yaml"
 
 permissions:
     packages: write
-    id-token: write
-    contents: read
 
 jobs:
-    docker:
-        name: Update docker images
+    backend:
+        name: Update backend docker images
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
@@ -32,23 +35,3 @@ jobs:
               run: |
                   docker compose -f docker-compose.yaml build
                   docker push ghcr.io/ansengarvin/backend:latest
-    frontend:
-        name: Deploy frontend
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v4
-
-            - name: Build front end
-              run: |
-                  npm install
-                  npm run build
-              working-directory: frontend
-
-            - name: Deploy front end
-              uses: Azure/static-web-apps-deploy@v1
-              with:
-                  azure_static_web_apps_api_token: ${{ secrets.AZURE_FRONTEND_DEPLOYMENT_TOKEN }}
-                  action: upload
-                  app_location: "./frontend/dist"
-                  skip_app_build: true

--- a/.github/workflows/cd_front.yaml
+++ b/.github/workflows/cd_front.yaml
@@ -20,6 +20,12 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v4
 
+            - name: Cache dependencies
+              uses: actions/cache@v4
+              with:
+                  key: frontend-node-modules-${{ hashFiles('**/package-lock.json') }}
+                  path: frontend/node_modules
+
             - name: Build front end
               run: |
                   npm install

--- a/.github/workflows/cd_front.yaml
+++ b/.github/workflows/cd_front.yaml
@@ -24,7 +24,7 @@ jobs:
               uses: actions/cache@v4
               with:
                   key: cd-frontend-node-modules-${{ hashFiles('**/package-lock.json') }}
-                  path: frontendnode_modules
+                  path: frontend/node_modules
 
             - name: Build front end
               run: |

--- a/.github/workflows/cd_front.yaml
+++ b/.github/workflows/cd_front.yaml
@@ -24,8 +24,7 @@ jobs:
               uses: actions/cache@v4
               with:
                   key: cd-frontend-node-modules-${{ hashFiles('**/package-lock.json') }}
-                  path: node_modules
-              working-directory: frontend
+                  path: frontendnode_modules
 
             - name: Build front end
               run: |

--- a/.github/workflows/cd_front.yaml
+++ b/.github/workflows/cd_front.yaml
@@ -24,7 +24,8 @@ jobs:
               uses: actions/cache@v4
               with:
                   key: frontend-node-modules-${{ hashFiles('**/package-lock.json') }}
-                  path: frontend/node_modules
+                  path: node_modules
+              working-directory: frontend
 
             - name: Build front end
               run: |
@@ -37,5 +38,6 @@ jobs:
               with:
                   azure_static_web_apps_api_token: ${{ secrets.AZURE_FRONTEND_DEPLOYMENT_TOKEN }}
                   action: upload
-                  app_location: "./frontend/dist"
+                  app_location: "./dist"
                   skip_app_build: true
+              working-directory: frontend

--- a/.github/workflows/cd_front.yaml
+++ b/.github/workflows/cd_front.yaml
@@ -23,7 +23,7 @@ jobs:
             - name: Cache dependencies
               uses: actions/cache@v4
               with:
-                  key: frontend-node-modules-${{ hashFiles('**/package-lock.json') }}
+                  key: cd-frontend-node-modules-${{ hashFiles('**/package-lock.json') }}
                   path: node_modules
               working-directory: frontend
 

--- a/.github/workflows/cd_front.yaml
+++ b/.github/workflows/cd_front.yaml
@@ -1,0 +1,35 @@
+name: cd_front
+
+on:
+    push:
+        branches:
+            - main
+        paths:
+            - "frontend/**"
+            - ".github/workflows/cd_front.yaml"
+
+permissions:
+    id-token: write
+    contents: read
+
+jobs:
+    frontend:
+        name: Deploy frontend
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Build front end
+              run: |
+                  npm install
+                  npm run build
+              working-directory: frontend
+
+            - name: Deploy front end
+              uses: Azure/static-web-apps-deploy@v1
+              with:
+                  azure_static_web_apps_api_token: ${{ secrets.AZURE_FRONTEND_DEPLOYMENT_TOKEN }}
+                  action: upload
+                  app_location: "./frontend/dist"
+                  skip_app_build: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,12 @@ jobs:
               with:
                   node-version: latest
 
+            - name: Cache dependencies
+              uses: actions/cache@v4
+              with:
+                  key: ci-lint-node-modules-${{ hashFiles('**/package-lock.json') }}
+                  path: node_modules
+
             - name: Install dependencies
               run: npm install
 
@@ -33,6 +39,13 @@ jobs:
               uses: actions/setup-node@v4
               with:
                   node-version: latest
+
+            - name: Cache dependencies
+              uses: actions/cache@v4
+              with:
+                  key: ci-frontend-node-modules-${{ hashFiles('**/package-lock.json') }}
+                  path: node_modules
+              working-directory: frontend
 
             - name: Install dependencies
               run: npm install
@@ -60,6 +73,12 @@ jobs:
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
+
+            - name: Cache dependencies
+              uses: actions/cache@v4
+              with:
+                  key: ci-test-node-modules-${{ hashFiles('**/package-lock.json') }}
+                  path: node_modules
 
             - name: Install test prerequisites
               run: npm install

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,8 +44,7 @@ jobs:
               uses: actions/cache@v4
               with:
                   key: ci-frontend-node-modules-${{ hashFiles('**/package-lock.json') }}
-                  path: node_modules
-              working-directory: frontend
+                  path: frontend/node_modules
 
             - name: Install dependencies
               run: npm install


### PR DESCRIPTION
- CI and CD workflows will cache node modules to eliminate npm install time unless dependencies change
- CD jobs have been split into two separate front and back end deployment workflows (cd-front and cd-back), so they won't execute unless the front or back end have changes